### PR TITLE
Fix issue #14 for single install iso

### DIFF
--- a/inc/DetectWindowsName.ps1
+++ b/inc/DetectWindowsName.ps1
@@ -7,7 +7,8 @@ function DetectWindowsName($iso) {
     Log "DEBUG" "Install.wim location: $installwim"
 
     $metaData = ExtractXMLFromWIM $installwim
-    $windowsBase = $metaData.WIM.IMAGE[0].NAME.Substring(0, $metaData.WIM.IMAGE[0].NAME.LastIndexOf(' '))
+    [array]$wimImages = $metaData.WIM.IMAGE
+    $windowsBase = $wimImages[0].NAME.Substring(0, $wimImages[0].NAME.LastIndexOf(' '))
     Log "INFO" "Detected: $windowsBase"
     Write-Host "`tDetected " -NoNewLine
     Write-Host "$windowsBase" -ForegroundColor Yellow

--- a/inc/PrepareInstallWIM.ps1
+++ b/inc/PrepareInstallWIM.ps1
@@ -11,8 +11,9 @@ function PrepareInstallWIM($iso, $outputfolder) {
 	Log "DEBUG" "Original WIM: $installwim"
 
     $metaData = ExtractXMLFromWIM $installwim
-	$amountOfImages = $metaData.WIM.IMAGE.Length
-	Log "INFO" "Found $amountOfImages images!"
+    [array]$wimImages = $metaData.WIM.IMAGE
+    $amountOfImages = $wimImages.Length
+    Log "INFO" "Found $amountOfImages images!"
     Write-Host "`tFound " $amountOfImages "images!"
 
     New-Item -Force -ItemType directory -Path $destinationfolder | Out-Null
@@ -34,13 +35,13 @@ function PrepareInstallWIM($iso, $outputfolder) {
     }
 
     For ($imageIndex=1; $imageIndex -le $amountOfImages; $imageIndex++) {
-        $imageName = $metaData.WIM.IMAGE[$imageIndex-1].NAME
+        $imageName = $wimImages[$imageIndex-1].NAME
         $fileName = $imageName
 
         if ($Optimization -eq 1) {
-            $fileName = $metaData.WIM.IMAGE[$imageIndex-1].WINDOWS.INSTALLATIONTYPE + ".wim"
+            $fileName = $wimImages[$imageIndex-1].WINDOWS.INSTALLATIONTYPE + ".wim"
         } elseif ($Optimization -eq 2) {
-            $fileName = $metaData.WIM.IMAGE[$imageIndex-1].WINDOWS.EDITIONID + ".wim"
+            $fileName = $wimImages[$imageIndex-1].WINDOWS.EDITIONID + ".wim"
         } elseif ($Optimization -eq 3) {
             $fileName = "install.wim"
         }


### PR DESCRIPTION
Assign $metaData.WIM.IMAGE to an array to ensure $metaData.WIM.IMAGE[0] is always valid. 